### PR TITLE
x11-terms/hyper: Remove rpm and deb from build process

### DIFF
--- a/x11-terms/hyper/hyper-1.3.3.ebuild
+++ b/x11-terms/hyper/hyper-1.3.3.ebuild
@@ -10,7 +10,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE=""
-DEPEND="app-arch/rpm
+DEPEND="
 	media-gfx/graphicsmagick
 	media-libs/libicns
 	net-libs/nodejs[npm]"
@@ -22,6 +22,7 @@ src_prepare() {
 	einfo "as NPM otherwise tries to create it, violating the sandbox rules."
 	einfo "See https://github.com/npm/npm/issues/11486"
 	npm install || npm run rebuild-node-pty && npm install || die "npm die failed!" # Not a nice solution, but it works for now
+	sed -i 's/"build": {/"donotbuild": {/g' package.json
 	eapply_user
 }
 


### PR DESCRIPTION
Trying to build deb packages fails on my system, which I though was odd anyway since the ebuild doesn't require a deb or rpm package to function. I just added a sed line to get rid of rpm and deb targets in the package.json file (which also removes the need for app-arch/rpm). This works on both the 1.3.3 release and the upstream github package.json